### PR TITLE
Update default JACK conf tool

### DIFF
--- a/dbus_constants.h
+++ b/dbus_constants.h
@@ -95,6 +95,6 @@
 #define LADISH_DBUS_ERROR_KEY_NOT_FOUND       DBUS_NAME_BASE ".Error.KeyNotFound"
 
 #define LADISH_CONF_KEY_JACK_CONF_TOOL            "/org/ladish/jack_conf_tool"
-#define LADISH_CONF_KEY_JACK_CONF_TOOL_DEFAULT    "ladiconf"
+#define LADISH_CONF_KEY_JACK_CONF_TOOL_DEFAULT    "ladi-control-center"
 
 #endif /* #ifndef DBUS_CONSTANTS_H__C21DE0EE_C19C_42F0_8D63_D613E4806C0E__INCLUDED */


### PR DESCRIPTION
So it matches the [name](https://github.com/alessio/laditools/blob/master/ladi-control-center) as it is now in your fork of laditools (has that become the de facto upstream?) 
