### PR TITLE
Fix GetAllPorts D-Bus method declaration

### DIFF
--- a/daemon/graph.c
+++ b/daemon/graph.c
@@ -3043,7 +3043,7 @@ bool ladish_graph_copy(ladish_graph_handle src, ladish_graph_handle dest)
 }
 
 CDBUS_METHOD_ARGS_BEGIN(GetAllPorts, "Get all ports")
-  CDBUS_METHOD_ARG_DESCRIBE_IN("ports_list", "as", "List of all ports")
+  CDBUS_METHOD_ARG_DESCRIBE_OUT("ports_list", "as", "List of all ports")
 CDBUS_METHOD_ARGS_END
 
 CDBUS_METHOD_ARGS_BEGIN(GetGraph, "Get whole graph")


### PR DESCRIPTION
This pull request has been open for almost two years on the original repo. Was [just made aware](https://github.com/LADI/ladish/commit/5fe205f2dc5931854a1126ca50bf682eca959430#commitcomment-28054786) that this is ladish's new home, so moving it over.

Anyway, `GetAllPorts` in the `org.jackaudio.JackPatchbay` proxy interface has its output set as an input argument. This PR fixes that.